### PR TITLE
Create Builddir

### DIFF
--- a/com.gitlab.Murmele.UDPLogger.yaml
+++ b/com.gitlab.Murmele.UDPLogger.yaml
@@ -65,6 +65,7 @@ modules:
 
 - name: UDPLogger
   buildsystem: cmake-ninja
+  builddir: true
   sources:
   - type: git
     url: *git_url


### PR DESCRIPTION
Otherwise we are gettings a ninja error because a dependency cycle occurs

```
ninja: error: dependency cycle: libUDPLoggerLib.a -> CMakeFiles/UDPLoggerLib.dir/UDPLoggerLib_autogen/mocs_compilation.cpp.o -> cmake_object_order_depends_target_UDPLoggerLib -> l18n/udplogger_be.ts -> UDPLogger_autogen/mocs_compilation.cpp -> UDPLogger_autogen_timestamp_deps -> CMakeFiles/UDPLogger_autogen_timestamp_deps -> libUDPLoggerLib.a
Error: module UDPLogger: Der Kindprozess wurde mit Status 1 beendet
```